### PR TITLE
Remove yardoc task and yard dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require "bundler/gem_tasks"
 require "rake/manifest/task"
 
 import "tasks/test.rake"
-import "tasks/yardoc.rake"
 
 Rake::Manifest::Task.new do |t|
   t.patterns = ["lib/**/*.rb", "*.md", "COPYING.LIB"]

--- a/gir_ffi-tracker.gemspec
+++ b/gir_ffi-tracker.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
-  spec.add_development_dependency "yard", "~> 0.9.14"
 end

--- a/tasks/yardoc.rake
+++ b/tasks/yardoc.rake
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require "yard"
-
-YARD::Rake::YardocTask.new do |t|
-  t.files   = ["lib/**/*.rb"]
-  t.options = ["--private", "--protected", "--readme", "README.md"]
-end


### PR DESCRIPTION
Yard can just be run by itself and outside of the bundle.
