### PR TITLE
Update RuboCop configuration and handle new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-minitest
   - rubocop-packaging

--- a/gir_ffi-tracker.gemspec
+++ b/gir_ffi-tracker.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/test/unit/tracker_sparql_cursor_test.rb
+++ b/test/unit/tracker_sparql_cursor_test.rb
@@ -21,6 +21,7 @@ describe Tracker::SparqlCursor do
 
     it "can safely be called twice" do
       @cursor.get_string(0)
+
       _(@cursor.get_string(0)).must_equal "Foo"
     end
   end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
