### PR TITLE
Remove old ffi-tracker compatibility file

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,4 +1,3 @@
-lib/ffi-tracker.rb
 lib/gir_ffi-tracker.rb
 lib/gir_ffi-tracker/version.rb
 Changelog.md

--- a/lib/ffi-tracker.rb
+++ b/lib/ffi-tracker.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require "gir_ffi-tracker"


### PR DESCRIPTION
This gem hasn't been called ffi-tracker since 2012, so this compatibility can safely be dropped.
